### PR TITLE
Add option to sudo or not to sudo

### DIFF
--- a/cappa.py
+++ b/cappa.py
@@ -19,7 +19,7 @@ def warn(*objs):
     print("WARNING: ", *objs, file=sys.stderr)
 
 class CapPA(object):
-    def __init__(self, warn_mode, private_https_oauth=False):
+    def __init__(self, warn_mode, private_https_oauth=False, use_venv=True):
         self.npm = find_executable('npm')
         self.bower = find_executable('bower')
         self.pip = find_executable('pip')
@@ -27,6 +27,7 @@ class CapPA(object):
         self.sys = find_executable('apt-get')
         self.warn_mode = warn_mode
         self.private_https_oauth = private_https_oauth
+        self.use_venv = use_venv
 
     def install(self, packages):
         if isinstance(packages, dict):
@@ -84,6 +85,8 @@ class CapPA(object):
                     prefix.append('sudo')
                 elif key == 'pip':
                     options.append('-U')
+                    if not self.use_venv:
+                        prefix.append('sudo')
 
                 range_connector_gte = ">="
                 range_connector_lt = "<"

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -17,9 +17,11 @@ def cappa():
               help='print errors as warning and continue')
 @click.option('--private-https-oauth', is_flag=True,
               help='Use oauth authenticated https for private repositories (requires GITHUB_TOKEN env var)')
+@click.option('--use-venv/--no-venv', default=True,
+              help='Assumes install uses a python virtualenv')
 @click.argument('packages', nargs=-1)
-def install(requirements, warn, private_https_oauth, packages):
-    pa = CapPA(warn, private_https_oauth)
+def install(requirements, warn, private_https_oauth, use_venv, packages):
+    pa = CapPA(warn, private_https_oauth, use_venv)
     if requirements is None:
         pa.install(packages)
     else:


### PR DESCRIPTION
When running on ubuntu machines in deployed instances, we need to install the python packages globally as sudo, so this adds an option to enable that.