### PR TITLE
don't upgrade pip packages automatically

### DIFF
--- a/cappa.py
+++ b/cappa.py
@@ -89,10 +89,8 @@ class CapPA(object):
                 elif key == 'sys':
                     options.append('-y')
                     prefix.append('sudo')
-                elif key == 'pip':
-                    options.append('-U')
-                    if not self.use_venv:
-                        prefix.append('sudo')
+                elif key == 'pip' and not self.use_venv:
+                    prefix.append('sudo')
 
                 range_connector_gte = ">="
                 range_connector_lt = "<"


### PR DESCRIPTION
This makes it so that we don't automatically upgrade pip packages when installing, to avoid version conflicts between packages with locked versions, and those that don't.