### PR TITLE
Add pip with python3 and pypy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 -----
 
 - Bug fix: Fix bug where cappa does not recheck for executables if previous step installs the package manager
+- Add support for python3 and pypy
 - Unit tests
 
 0.8

--- a/cappa.py
+++ b/cappa.py
@@ -33,13 +33,15 @@ IS_UBUNTU = platform.dist()[0] == 'Ubuntu'
 
 
 class CapPA(object):
-    ALL_MANAGERS = ('npm', 'npmg', 'bower', 'tsd', 'pip', 'sys', 'Captricity')
+    ALL_MANAGERS = ('npm', 'npmg', 'bower', 'tsd', 'pip', 'pip3', 'pip_pypy', 'sys', 'Captricity')
 
     def __init__(self, warn_mode, private_https_oauth=False, use_venv=True):
         self.npm = find_executable('npm')
         self.bower = find_executable('bower')
         self.tsd = find_executable('tsd')
         self.pip = find_executable('pip')
+        self.pip3 = find_executable('pip3')
+        self.pip_pypy = find_executable('pip')
         # TODO: support for osx
         self.sys = find_executable('apt-get')
         self.warn_mode = warn_mode
@@ -69,9 +71,18 @@ class CapPA(object):
                 raise MissingExecutable('tsd not found')
             elif manager_type == 'pip':
                 raise MissingExecutable('pip not found')
+            elif manager_type == 'pip3':
+                raise MissingExecutable('pip3 not found')
+            elif manager_type == 'pip_pypy':
+                raise MissingExecutable('pip not found')
             elif manager_type == 'sys':
                 raise MissingExecutable('apt-get not found')
         else:
+            if manager_type == 'pip_pypy':
+                pypy_object = find_executable('pypy')
+                if pypy_object is None:
+                    raise MissingExecutable('pypy not found')
+                return 'pip'
             return manager_obj
 
     def _install_package_dict(self, package_dict):
@@ -112,8 +123,11 @@ class CapPA(object):
                 elif key == 'sys':
                     options.append('-y')
                     prefix.append('sudo')
-                elif key == 'pip' and not self.use_venv:
+                elif key in ['pip', 'pip3', 'pip_pypy'] and not self.use_venv:
                     prefix.append('sudo')
+                if key == 'pip_pypy':
+                    prefix.append('pypy')
+                    prefix.append('-m')
 
                 range_connector_gte = ">="
                 range_connector_lt = "<"
@@ -121,7 +135,7 @@ class CapPA(object):
                     connector = '@'
                 elif key == 'bower':
                     connector = '#'
-                elif key == 'pip':
+                elif key in ['pip', 'pip3', 'pip_pypy']:
                     connector = '=='
                 elif key == 'sys':
                     connector = None  # does not support versioning
@@ -232,7 +246,7 @@ class CapPA(object):
 
     def _clean_pip_residuals(self):
         """ Check for residual tmp files left by pip """
-        if self.pip:
+        if self.pip or self.pip3 or self.pip_pypy:
             tmp_location = os.environ.get('TMPDIR',
                                           os.environ.get('TEMP',
                                                          os.environ.get('TMP', '/tmp')))
@@ -254,7 +268,10 @@ class CapPA(object):
 
     @staticmethod
     def extract_manager(package):
-        if not (package.startswith('pip') or package.startswith('bower') or
+        if not (package.startswith('pip_pypy') or
+                package.startswith('pip3') or
+                package.startswith('pip') or
+                package.startswith('bower') or
                 package.startswith('npm')):
             raise UnknownManager("Could not identify base package manager for '{}'".format(package))
 

--- a/cappa.py
+++ b/cappa.py
@@ -63,20 +63,12 @@ class CapPA(object):
             manager_obj = find_executable(manager_type)  # Might have been installed in a previous step
 
         if manager_obj is None:
-            if manager_type == 'npm':
-                raise MissingExecutable('npm not found')
-            elif manager_type == 'bower':
-                raise MissingExecutable('bower not found')
-            elif manager_type == 'tsd':
-                raise MissingExecutable('tsd not found')
-            elif manager_type == 'pip':
-                raise MissingExecutable('pip not found')
-            elif manager_type == 'pip3':
-                raise MissingExecutable('pip3 not found')
-            elif manager_type == 'pip_pypy':
+            if manager_type == 'pip_pypy':
                 raise MissingExecutable('pip not found')
             elif manager_type == 'sys':
                 raise MissingExecutable('apt-get not found')
+            else:
+                raise MissingExecutable('{} not found'.format(manager_type))
         else:
             if manager_type == 'pip_pypy':
                 pypy_object = find_executable('pypy')

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -58,7 +58,7 @@ cappa.add_command(remove)
 
 @click.command()
 def version():
-    click.echo('0.8.2')
+    click.echo('0.8.3')
 cappa.add_command(version)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "cappa",
-    version = "0.8.2",
+    version = "0.8.3",
     description = "Package installer for Captricity. Supports apt-get, pip, bower, and npm.",
     author = "Yoriyasu Yano",
     author_email = "yorinasub17@gmail.com",

--- a/tests/serverspecs/spec/default/pip3_install_basic_spec.rb
+++ b/tests/serverspecs/spec/default/pip3_install_basic_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe command('pip show Django') do
+  let(:disable_sudo) { true }
+  its(:stdout) { should eq '' }
+end
+
+describe command('pip3 show Django') do
+  let(:disable_sudo) { true }
+  its(:stdout) { should contain('Version: 1.8.5') }
+end

--- a/tests/serverspecs/spec/default/pip_pypy_install_basic_spec.rb
+++ b/tests/serverspecs/spec/default/pip_pypy_install_basic_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe command('pip show Django') do
+  let(:disable_sudo) { true }
+  its(:stdout) { should contain('Version: 1.8.5') }
+  its(:stdout) { should contain('pypy') }
+end

--- a/tests/serverspecs/spec/default/system_basic_spec.rb
+++ b/tests/serverspecs/spec/default/system_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe command('cappa version') do
-    its(:stdout) { should match /0.8.2/ }
+    its(:stdout) { should match /0.8.3/ }
 end

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -1,7 +1,19 @@
 from __future__ import absolute_import
 
 from .base import VagrantTestCase
+from fabric.api import task, sudo, run, cd
 from tests.dependencies import PYTHON_DEPENDENCIES, VIRTUALENV_DEPENDENCIES
+
+
+@task
+def setup_pypy():
+    """Installs pypy on the vagrant box."""
+    sudo('add-apt-repository -y ppa:pypy/ppa')
+    sudo('apt-get -y update')
+    sudo('apt-get -y install pypy')
+    with cd('~'):
+        run('curl -O https://bootstrap.pypa.io/get-pip.py')
+        sudo('pypy get-pip.py')
 
 
 class PipTestCases(VagrantTestCase):
@@ -12,9 +24,33 @@ class PipTestCases(VagrantTestCase):
         self.install_requirements_json_with_virtualenv(TEST_INSTALL_PIP_VERSION_JSON)
         self.run_spec('pip_install_basic_spec')
 
+    def test_pip3(self):
+        self.install_requirements_json(TEST_INSTALL_PIP3_VERSION_JSON)
+        self.run_spec('pip3_install_basic_spec')
+
+    def test_pip_pypy(self):
+        self.run_fabric_task(setup_pypy)
+        self.install_requirements_json(TEST_INSTALL_PIPPYPY_VERSION_JSON)
+        self.run_spec('pip_pypy_install_basic_spec')
 
 TEST_INSTALL_PIP_VERSION_JSON = """{
     "pip": {
         "django-extensions": "1.5.5"
+    }
+}"""
+
+TEST_INSTALL_PIP3_VERSION_JSON = """{
+    "sys": {
+        "python3-pip": null,
+        "git": null
+    },
+    "pip3": {
+        "django": "1.8.5"
+    }
+}"""
+
+TEST_INSTALL_PIPPYPY_VERSION_JSON = """{
+    "pip_pypy": {
+        "django": "1.8.5"
     }
 }"""


### PR DESCRIPTION
Adds two more managers:
- `pip3` for python3 pip
- `pip_pypy` for pypy pip

Test with `python setup.py test` or `python -m unittest tests.test_pip` for a shorter test cycle.

FYI @woohp 