### PR TITLE
Cappa script: python3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.9
+---
+
+- Python3 support
+
 0.8.X
 -----
 

--- a/cappa.py
+++ b/cappa.py
@@ -8,6 +8,7 @@ import subprocess
 import platform
 import json
 import collections
+import six
 from distutils.spawn import find_executable
 from contextlib import contextmanager
 
@@ -81,7 +82,7 @@ class CapPA(object):
         if 'sys' in package_dict:
             self._update_apt_cache()
 
-        for key, packages in package_dict.iteritems():
+        for key, packages in six.iteritems(package_dict):
             try:
                 if key == 'Captricity':
                     self._private_package_dict(packages)
@@ -136,7 +137,7 @@ class CapPA(object):
 
                 manager = self._assert_manager_exists(key)
                 args = prefix + [manager, 'install'] + options
-                for package, version in packages.iteritems():
+                for package, version in six.iteritems(packages):
                     if version is None or connector is None:
                         args.append(package)
                     elif isinstance(version, list):
@@ -155,7 +156,8 @@ class CapPA(object):
 
     def _install_package_list(self, packages):
         split = map(CapPA.extract_manager, packages)
-        for key, packages in cytoolz.itertoolz.groupby(operator.itemgetter(0), split).iteritems():
+        grouped_packages = cytoolz.itertoolz.groupby(operator.itemgetter(0), split)
+        for key, packages in six.iteritems(grouped_packages):
             manager = self._assert_manager_exists(key)
             options = list(set(sum(map(operator.itemgetter(2), packages), [])))
             packages = map(operator.itemgetter(1), packages)
@@ -234,7 +236,7 @@ class CapPA(object):
             prefix = []
             if not IS_MAC:
                 prefix.append('sudo')
-            subprocess.check_call(prefix + ['rm', '-rf', os.path.join(tmp_location, 'npm-*')])
+            subprocess.check_call(prefix + ['rm', '-rf', os.path.join(str(tmp_location), 'npm-*')])
 
     def _clean_pip_residuals(self):
         """ Check for residual tmp files left by pip """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click
 cytoolz
+six

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -60,7 +60,7 @@ cappa.add_command(remove)
 
 @click.command()
 def version():
-    click.echo('0.8.3')
+    click.echo('0.9')
 cappa.add_command(version)
 
 if __name__ == '__main__':

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -13,7 +13,7 @@ def cappa():
 
 
 @click.command()
-@click.option('--requirements', '-r', default=None, type=click.File('rb'),
+@click.option('--requirements', '-r', default=None, type=click.File('r'),
               help='install using requirements json file')
 @click.option('--warn', is_flag=True,
               help='print errors as warning and continue')
@@ -40,7 +40,7 @@ def install(requirements, warn, private_https_oauth, use_venv, ignore, only, pac
     if requirements is None:
         pa.install(packages, ignore_managers=ignore)
     else:
-        pa.install(json.loads(requirements.read(), object_pairs_hook=collections.OrderedDict), ignore_managers=ignore)
+        pa.install(json.load(requirements, object_pairs_hook=collections.OrderedDict), ignore_managers=ignore)
 cappa.add_command(install)
 
 

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import click
 import json
 import collections

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "cappa",
-    version = "0.8.3",
+    version = "0.9",
     description = "Package installer for Captricity. Supports apt-get, pip, bower, and npm.",
     author = "Yoriyasu Yano",
     author_email = "yorinasub17@gmail.com",

--- a/tests/serverspecs/spec/default/npmg_install_basic_spec.rb
+++ b/tests/serverspecs/spec/default/npmg_install_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe command('npm show jshint') do
-  its(:stdout) { should contain("version: '2.8.0'") }
+describe command('jshint -v') do
+  its(:stderr) { should contain("v2.8.0") }
 end

--- a/tests/serverspecs/spec/default/system_basic_spec.rb
+++ b/tests/serverspecs/spec/default/system_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe command('cappa version') do
-    its(:stdout) { should match /0.8.3/ }
+    its(:stdout) { should match /0.9/ }
 end

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+from .base import VagrantTestCase
+from fabric.api import task, sudo, cd
+
+@task
+def setup_python3_cappa():
+    """Installs cappa on the vagrant box."""
+    with cd('/vagrant'):
+        sudo('apt-get -yy install python3-setuptools python3-dev')
+        sudo('python3 setup.py install')
+
+
+class Python3TestCases(VagrantTestCase):
+
+    def _setup_cappa(self):
+        self.run_fabric_task(setup_python3_cappa)
+
+    def test_pip3(self):
+        self.install_requirements_json(TEST_INSTALL_PIP3_VERSION_JSON)
+        self.run_spec('pip3_install_basic_spec')
+
+
+TEST_INSTALL_PIP3_VERSION_JSON = """{
+    "sys": {
+        "python3-pip": null,
+        "git": null
+    },
+    "pip3": {
+        "django": "1.8.5"
+    }
+}"""


### PR DESCRIPTION
Cappa script now supports python3 as a medium to run it.

In addition:
- Supports the [subdirectory directive](http://stackoverflow.com/questions/13566200/how-can-i-install-from-a-git-subdirectory-with-pip)
- Fix npmg test