### PR TITLE
bower installs using force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.11
+---
+
+- bower installs using -f
+
 0.10
 ---
 

--- a/cappa.py
+++ b/cappa.py
@@ -198,7 +198,7 @@ class CapPA(object):
         with self._chdir_to_target_if_set(package_dict):
             with open('bower.json', 'w') as f:
                 f.write(json.dumps(package_dict))
-            subprocess.check_call([bower, 'install'])
+            subprocess.check_call([bower, 'install', '-f'])
             if not self.save_js:
                 os.remove('bower.json')
 
@@ -299,7 +299,7 @@ class CapPA(object):
         elif manager == 'sys':
             connector = None  # does not support versioning
         else:
-            raise UnknownManager("Could not identify base package manager '{}'".format(key))
+            raise UnknownManager("Could not identify base package manager '{}'".format(manager))
 
         manager = self._assert_manager_exists(manager)
         args = prefix + [manager, 'install'] + options

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -90,7 +90,7 @@ cappa.add_command(remove)
 
 @click.command()
 def version():
-    click.echo('0.10')
+    click.echo('0.11')
 cappa.add_command(version)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 from setuptools import setup
 
 setup(
-    name = "cappa",
-    version = "0.10",
-    description = "Package installer for Captricity. Supports apt-get, pip, bower, and npm.",
-    author = "Yoriyasu Yano",
-    author_email = "yorinasub17@gmail.com",
+    name="cappa",
+    version="0.11",
+    description="Package installer for Captricity. Supports apt-get, pip, bower, and npm.",
+    author="Yoriyasu Yano",
+    author_email="yorinasub17@gmail.com",
 
-    py_modules = ["cappa"],
-    scripts = ["scripts/cappa"],
-    install_requires = open("requirements.txt").read().split(),
-    tests_requires = open("test_requirements.txt").read().split(),
+    py_modules=["cappa"],
+    scripts=["scripts/cappa"],
+    install_requires=open("requirements.txt").read().split(),
+    tests_requires=open("test_requirements.txt").read().split(),
     test_suite='tests'
 )

--- a/tests/serverspecs/spec/default/system_basic_spec.rb
+++ b/tests/serverspecs/spec/default/system_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe command('cappa version') do
-    its(:stdout) { should match /0.10/ }
+    its(:stdout) { should match(/0.11/) }
 end


### PR DESCRIPTION
When cappa runs bower install, it now runs it with the force flag, so that existing installed dependencies do not interfere with the dependency tree. Only the requirements specified in the requirements file will be used.

It makes the install a bit slower.