### PR TITLE
chdir when installing from requirements file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.12
+---
+
+- When installing from a requirements file, cappa will first change to the directory of the file.
+
 0.11
 ---
 

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import os
 import click
 import json
 import collections
@@ -50,10 +51,11 @@ def install(requirements,
     else:
         ignore = ignore.split(',')
 
-    if requirements is None:
-        pa.install(packages, ignore_managers=ignore)
-    else:
+    if requirements:
+        os.chdir(os.path.dirname(requirements.name))
         pa.install(json.load(requirements, object_pairs_hook=collections.OrderedDict), ignore_managers=ignore)
+    else:
+        pa.install(packages, ignore_managers=ignore)
 cappa.add_command(install)
 
 
@@ -90,7 +92,7 @@ cappa.add_command(remove)
 
 @click.command()
 def version():
-    click.echo('0.11')
+    click.echo('0.12')
 cappa.add_command(version)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="cappa",
-    version="0.11",
+    version="0.12",
     description="Package installer for Captricity. Supports apt-get, pip, bower, and npm.",
     author="Yoriyasu Yano",
     author_email="yorinasub17@gmail.com",

--- a/tests/serverspecs/spec/default/system_basic_spec.rb
+++ b/tests/serverspecs/spec/default/system_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe command('cappa version') do
-    its(:stdout) { should match(/0.11/) }
+    its(:stdout) { should match(/0.12/) }
 end


### PR DESCRIPTION
This is particular helpful when installing bower. Bower will install bower_components under `<target_dir>/bower_components`, and so if the current directory is not exactly that of requirements.json, it will install bower_components in the wrong place.