### PR TITLE
When installing bower requirements, prefer to use the bower in the local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.18
+---
+
+- bower install now prefers to use the bower in the local node_modules folder
+
 0.17
 ---
 

--- a/cappa/base.py
+++ b/cappa/base.py
@@ -26,7 +26,7 @@ class CapPA(object):
             if self.warn_mode:
                 warn(e)
             else:
-                raise e
+                raise
         finally:
             self._clean()
 

--- a/cappa/bower.py
+++ b/cappa/bower.py
@@ -6,7 +6,6 @@ import json
 import subprocess
 
 from .base import CapPA
-from .enums import IS_MAC
 
 
 class Bower(CapPA):
@@ -15,6 +14,12 @@ class Bower(CapPA):
         super(Bower, self).__init__(*flags)
         self.name = 'bower'
         self.friendly_name = 'bower'
+
+    def find_executable(self):
+        local_bower = 'node_modules/.bin/bower'
+        if os.path.exists(local_bower):
+            return local_bower
+        return super(Bower, self).find_executable()
 
     def _install_package_dict(self, packages):
         self._setup_bower()
@@ -44,8 +49,8 @@ class Bower(CapPA):
                 f.write('{"analytics": false}')
 
     def _bower_json_install(self, package_dict):
-        bower = self.find_executable()
         with self._chdir_to_target_if_set(package_dict):
+            bower = self.find_executable()
             with open('bower.json', 'w') as f:
                 f.write(json.dumps(package_dict))
             subprocess.check_call([bower, 'install', '-f'])

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -117,7 +117,7 @@ cappa.add_command(remove)
 
 @click.command()
 def version():
-    click.echo('0.17.1')
+    click.echo('0.18.0')
 cappa.add_command(version)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cappa",
-    version="0.17.1",
+    version="0.18.0",
     description="Package installer for Captricity. Supports apt-get, pip, bower, npm, and yarn.",
     author="Yoriyasu Yano",
     author_email="yorinasub17@gmail.com",

--- a/tests/serverspecs/spec/default/system_basic_spec.rb
+++ b/tests/serverspecs/spec/default/system_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe command('cappa version') do
-    its(:stdout) { should match(/0.17.1/) }
+    its(:stdout) { should match(/0.18.0/) }
 end


### PR DESCRIPTION
When installing bower requirements, prefer to use the bower in the local node_modules folder instead of the global one.