### PR TITLE
DEVOPS-3421: Need to lock down version in the requirements for Cappa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click
-cytoolz
-six
-PyYAML
+click==7.0
+cytoolz>=0.8.0, <=0.10.0
+six==1.10.0
+PyYAML==5.1.2


### PR DESCRIPTION
Set the versions of requirements for Cappa.

https://captricity.atlassian.net/browse/DEVOPS-3421

https://docs.google.com/spreadsheets/d/1x6MfryaY99QV5rfElOspDlgDKQiSowNfMOorRypsq7o/edit?ts=5dc099fe#gid=0