### PR TITLE
Force install yarn dependencies

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.1
+current_version = 0.18.3
 parse = (?P<major>\d+)\.(?P<minor>.*)\.(?P<patch>.*)
 serialize = {major}.{minor}.{patch}
 

--- a/cappa/yarn.py
+++ b/cappa/yarn.py
@@ -25,7 +25,7 @@ class Yarn(CapPA):
         range_connector_lt = "<"
         connector = '@'
         manager = self.find_executable()
-        args = [manager, 'add']
+        args = [manager, 'add', '-f']
         for package, version in six.iteritems(packages):
             if version is None:
                 args.append(package)

--- a/scripts/cappa
+++ b/scripts/cappa
@@ -117,7 +117,7 @@ cappa.add_command(remove)
 
 @click.command()
 def version():
-    click.echo('0.18.1')
+    click.echo('0.18.3')
 cappa.add_command(version)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cappa",
-    version="0.18.1",
+    version="0.18.3",
     description="Package installer for Captricity. Supports apt-get, pip, bower, npm, and yarn.",
     author="Yoriyasu Yano",
     author_email="yorinasub17@gmail.com",

--- a/tests/serverspecs/spec/default/system_basic_spec.rb
+++ b/tests/serverspecs/spec/default/system_basic_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe command('cappa version') do
-    its(:stdout) { should match(/0.18.1/) }
+    its(:stdout) { should match(/0.18.3/) }
 end


### PR DESCRIPTION
@JoshPaulsen 

This solves conflicting dependency versions by always using the version specified in our requirements file. Basically the same problem as #30.

I bumped two versions because 0.18.2 was released [in GitHub](https://github.com/Captricity/cappa/releases) but not in the source code.