### PR TITLE
update cytoolz for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-cytoolz>=0.8.0,<=0.10.0
+cytoolz>=0.8.0,<=0.11.0
 distro
 six
 PyYAML


### PR DESCRIPTION
update the requirement to `cytoolz>=0.8.0,<=0.11.0`
so that it will built with python 3.8

https://github.com/pytoolz/cytoolz/issues/136