### PR TITLE
CF-2342: unpinned cytoolz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-cytoolz>=0.8.0,<=0.11.0
+cytoolz
 distro
 six
 PyYAML


### PR DESCRIPTION
# CF-2342: unpinned cytoolz

For @ECSanchez 

For the upgrade to python 3.10 we need cytoolz 0.12.0.